### PR TITLE
deploy to branch path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
       - "docker/*"
 
   pull_request:
+    branches:
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -40,7 +40,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          if [ ${{github.event_name}} -eq 'pull_request' ]; then
+          if [ ${{github.event_name}} == 'pull_request' ]; then
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD^3)"
             BRANCH=${{ github.event.pull_request.head.ref }}
             echo "::set-output name=branch::${BRANCH:='stage'}"

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash
         run: |
           if [ ${{github.event_name}} == 'pull_request' ]; then
-            echo "::set-output name=sha_short::$(git rev-parse --short HEAD^3)"
+            echo "::set-output name=sha_short::$(git rev-parse --short HEAD^2)"
             BRANCH=${{ github.event.pull_request.head.ref }}
             echo "::set-output name=branch::${BRANCH:='stage'}"
           else

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -42,10 +42,9 @@ jobs:
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD^2)"
-            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD^1)"
+            echo "::set-output name=branch::${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"
           fi
 
       - name: build hash

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -46,6 +46,8 @@ jobs:
             echo "::set-output name=branch::${BRANCH:='stage'}"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+            BRANCH=${{ github.head.ref }}
+            echo "::set-output name=branch::${BRANCH:='stage'}"
           fi
 
       - name: build hash

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD^2)"
-            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD^2)"
+            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
             echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -41,9 +41,9 @@ jobs:
         shell: bash
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
-            echo "::set-output name=sha_short::$(git rev-parse --short HEAD^1)"
-            BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
-            echo "::set-output name=branch::$BRANCH"
+            echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+            BRANCH=${{ github.head_ref }}
+            echo "::set-output name=branch::${BRANCH:-stage}"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           fi

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD^2)"
-            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"
+            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD^1)"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
             echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -42,8 +42,10 @@ jobs:
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD^2)"
+            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD^2)"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+            echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"
           fi
 
       - name: build hash
@@ -55,15 +57,34 @@ jobs:
           cp -R public/* ~/out/mm/${{ steps.vars.outputs.sha_short }}/
 
       - name: build stage
-        run: hugo --baseURL=http://clfx.cc/mm/stage
+        run: hugo --baseURL=http://clfx.cc/mm/${{ steps.vars.outputs.branch }}
 
       - name: deploy stage
         run: |
-          rm -rf ~/out/mm/stage
-          mkdir -p ~/out/mm/stage
-          cp -R public/* ~/out/mm/stage
+          rm -rf ~/out/mm/${{ steps.vars.outputs.branch }}
+          mkdir -p ~/out/mm/${{ steps.vars.outputs.branch }}
+          cp -R public/* ~/out/mm/${{ steps.vars.outputs.branch }}
 
-      - name: find comment
+- name: find staging comment
+        uses: peter-evans/find-comment@v2
+        if: github.event_name == 'pull_request'
+        id: oc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Staging
+
+      - name: update staging comment
+        uses: peter-evans/create-or-update-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          comment-id: ${{ steps.oc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Staging: ${{ steps.vars.outputs.sha_short }}: https://clfx.cc/mm/${{ steps.vars.outputs.branch }}
+          edit-mode: replace
+
+      - name: find revision comment
         uses: peter-evans/find-comment@v2
         if: github.event_name == 'pull_request'
         id: fc
@@ -72,7 +93,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: Preview
 
-      - name: update comment
+      - name: update revision comment
         uses: peter-evans/create-or-update-comment@v2
         if: github.event_name == 'pull_request'
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -41,9 +41,9 @@ jobs:
         shell: bash
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
-            echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-            BRANCH=${{ github.head_ref }}
-            echo "::set-output name=branch::${BRANCH:-stage}"
+            echo "::set-output name=sha_short::$(git rev-parse --short HEAD^3)"
+            BRANCH=${{ github.event.pull_request.head.ref }}
+            echo "::set-output name=branch::${BRANCH:='stage'}"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           fi

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -41,8 +41,8 @@ jobs:
         shell: bash
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
-            echo "::set-output name=sha_short::$(git rev-parse --short HEAD^2)"
-            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+            echo "::set-output name=sha_short::$(git rev-parse --short HEAD^1)"
+            BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
             echo "::set-output name=branch::$BRANCH"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -42,7 +42,8 @@ jobs:
         run: |
           if [ ${{github.event_name}} -eq 'pull_request' ]; then
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD^2)"
-            echo "::set-output name=branch::${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+            BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+            echo "::set-output name=branch::$BRANCH"
           else
             echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           fi

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -65,7 +65,7 @@ jobs:
           mkdir -p ~/out/mm/${{ steps.vars.outputs.branch }}
           cp -R public/* ~/out/mm/${{ steps.vars.outputs.branch }}
 
-- name: find staging comment
+      - name: find staging comment
         uses: peter-evans/find-comment@v2
         if: github.event_name == 'pull_request'
         id: oc


### PR DESCRIPTION
No more `/stage`, now will have `/<branch>` and another comment in the PR linking to it.

The intent is to prevent collisions at the “memorable version” of the staging link when multiple PRs are open simultaneously, rather than multiple writes to `/stage`